### PR TITLE
Use V8 JavaScriptStackTraceApi to find log origin

### DIFF
--- a/lib/Bristol.js
+++ b/lib/Bristol.js
@@ -224,30 +224,32 @@ Bristol.prototype._getGlobals = function() {
 	return globals;
 };
 
+var originalPrepareStackTrace = Error.prepareStackTrace;
+var arrayPrepareStackTrace = function (err, stack) { return stack; };
 /**
  * Finds the origin of the Bristol log call, and supplies the file path and
  * line number.
+ * This function is using JavaScriptStackTraceApi to be as fast as possible:
+ * https://code.google.com/p/v8-wiki/wiki/JavaScriptStackTraceApi
  * @returns {null|{file, line}} An object containing the file path and line
  *      number of the originating Bristol call, or null if this information
  *      cannot be found.
  * @private
  */
 Bristol.prototype._getOrigin = function() {
-	var stack = (new Error()).stack.split(/\s*\n\s*(?:at\s)?/),
-		origin = null,
-		caller;
+	Error.prepareStackTrace = arrayPrepareStackTrace;
+	var stack = (new Error()).stack,
+		origin = null;
 	for (var i = 1; i < stack.length; i++) {
-		if (!stack[i].match(/^Bristol\./)) {
-			caller = stack[i].match(/([^:\s\(]+):(\d+):(\d+)\)?$/);
+		if (stack[i].getThis() != this) {
+			origin = {
+				file: stack[i].getFileName(),
+				line: stack[i].getLineNumber()
+			};
 			break;
 		}
 	}
-	if (caller && caller.length == 4) {
-		origin = {
-			file: caller[1],
-			line: caller[2]
-		};
-	}
+	Error.prepareStackTrace = originalPrepareStackTrace;
 	return origin;
 };
 


### PR DESCRIPTION
`_getOrigin` method is extremely slow because regular expression is used to parse stack string. I've created a simple app: [bristol-test](https://github.com/bartekn/bristol-test) to prove the point and observed that even only 30 calls to `bristol.log` under heavy load can slow the app 10 times.

In this PR I'm using [`JavaScriptStackTraceApi`](https://code.google.com/p/v8-wiki/wiki/JavaScriptStackTraceApi) to get array of `CallSite` objects what allows to find a log call origin much faster. Overwriting `Error.prepareStackTrace` function looks bad but it's the only way to make this method faster. I'm switching to the original `Error.prepareStackTrace` function at the end of this method.

[bristol-test](https://github.com/bartekn/bristol-test) results for 2000 request (200 concurent requests):

|  | regexp method | `JavaScriptStackTraceApi` method |
| --- | --- | --- |
| Requests per second | 149.55 | 794.86 |
| Longest request [ms] | 1531 | 385 |
